### PR TITLE
Add missed argument

### DIFF
--- a/ui2d/ui2d.lua
+++ b/ui2d/ui2d.lua
@@ -495,7 +495,7 @@ local function UpdateLayout( bbox )
 	layout.same_column = false
 end
 
-local function Slider( type, name, v, v_min, v_max, width, tooltip )
+local function Slider( type, name, v, v_min, v_max, width, num_decimals, tooltip )
 	local text = GetLabelPart( name )
 	local cur_window = windows[ begin_idx ]
 	local text_w = font.handle:getWidth( text )


### PR DESCRIPTION
num_decimals argument is missing in the `Slider`
```lua
function UI2D.SliderFloat(name, v, v_min, v_max, width, num_decimals, tooltip)
  return Slider(e_slider_type.float, name, v, v_min, v_max, width, num_decimals, tooltip)
end
```